### PR TITLE
Fixes the load diagram problem on page change

### DIFF
--- a/cypress/integration/diagram.verification.spec.js
+++ b/cypress/integration/diagram.verification.spec.js
@@ -1,5 +1,6 @@
 describe('Diagrams appearance', () => {
     it('checks if text is appropriately converted to diagrams', () => {
+        // Visits the root first
         // Visit the root of example
         cy.visit("/");
 
@@ -17,5 +18,23 @@ describe('Diagrams appearance', () => {
                 .should('have.attr', 'src')
                 .should('include', 'https://www.websequencediagrams.com/cgi-bin/cdraw');
         });
+
+        // Visits the sub tab later
+        cy.visit("#/./sequence-xyz");
+        
+        cy.get('div[class="wsd"]').then(els => {
+            // Ensure that wsd div should have 1 child,
+            // As that child would be generated image
+            expect(els.length).to.be.equal(1);
+
+            // Ensure that image has a source of WebSequenceDiagrams
+            // Irrespective of the contents in it
+            cy.get('div[class="wsd"]')
+                .find('img')
+                .should('have.attr', 'src')
+                .should('include', 'https://www.websequencediagrams.com/cgi-bin/cdraw');
+        });
+
+        // Both visits should result in the rightful diagram
     });
 });

--- a/example/_sidebar.md
+++ b/example/_sidebar.md
@@ -1,0 +1,6 @@
+<!-- user_generate_content/_sidebar.md -->
+
+
+* [HOME](./)
+
+* [Diagram 2](./sequence-xyz.md)

--- a/example/index.html
+++ b/example/index.html
@@ -1,22 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <title>Document</title>
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="description" content="Description">
-  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta name="viewport"
+    content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/vue.css">
 </head>
+
 <body>
   <div id="app"></div>
   <script>
     window.$docsify = {
       name: '',
-      repo: ''
+      repo: '',
+      el: '#app',
+      loadSidebar: true
     }
   </script>
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
   <script src="./dist/docsify-websequencediagrams.js"></script>
 </body>
+
 </html>

--- a/example/sequence-xyz.md
+++ b/example/sequence-xyz.md
@@ -1,0 +1,12 @@
+# An arbitary diagram
+
+```websequencediagrams
+title Arbitary
+
+Alice->Bob: Authentication Request
+note right of Bob: Bob thinks about it
+Bob->Alice: Authentication Response
+
+A->+B: text
+B-->-A: text
+```

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,5 +1,11 @@
-let plugin = (hook, vm) => {
+const loadWSD = function () {
+    var wsdScript = document.createElement("script");
+    wsdScript.id = "wsd_loaded";
+    wsdScript.src = "https://www.websequencediagrams.com/service.js";
+    window.Docsify.dom.$.head.appendChild(wsdScript);
+};
 
+let plugin = (hook, vm) => {
     hook.afterEach(function (html, next) {
         // We load the HTML inside a DOM node to allow for manipulation
         var htmlElement = document.createElement('div');
@@ -25,14 +31,21 @@ let plugin = (hook, vm) => {
 
         // Do the magic!
         next(htmlElement.innerHTML);
+
+        // In case of WSD already present in the space, it needs to be recalled
+        setTimeout(function wsd_present_diagrams() {
+            if (window.document.querySelector('#wsd_loaded')) {
+                var myConcern = document.querySelector('#wsd_loaded');
+                myConcern.parentNode.removeChild(myConcern);
+                loadWSD();
+            } else setTimeout(wsd_present_diagrams, 100); // else re-schedule
+        }, 1000);
     });
 
     hook.ready(function () {
         // Lets the websequence do the magic
-        window.Docsify.dom.documentReady(function() {
-            var wsdScript = document.createElement("script");
-            wsdScript.src = "https://www.websequencediagrams.com/service.js";
-            window.Docsify.dom.$.head.appendChild(wsdScript);
+        window.Docsify.dom.documentReady(function () {
+            loadWSD();
         });
     });
 };


### PR DESCRIPTION
When we use to change the page, WSD didn't reload as the script would only function once.

Added a timeout setup to do the reload again, once the page is changed or new render call comes in.